### PR TITLE
reset line numbers

### DIFF
--- a/src/tokenizer.shared.js
+++ b/src/tokenizer.shared.js
@@ -106,6 +106,8 @@ var getTokens = (function() {
         if (!s) return [];
 
         tokens = [];
+        tn = 0;
+        ln = 1;
 
         var c, cn;
 


### PR DESCRIPTION
This makes gonzales better reusable for multiple passes, especially when
reporting line numbers.

I'm using this patch here: https://github.com/metapolator/metapolator/commit/f234e0a424e152e7ef72e47df5c6da684bd85823
